### PR TITLE
Latest retrofit(1.9.0) , okhttp(2.2.0) dependencies

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -19,9 +19,9 @@
     <name>Retrofit Bundle</name>
     
     <properties>
-        <retrofit.version>1.6.1</retrofit.version>
-        <okhttp.version>2.0.0</okhttp.version>
-        <okio.version>1.0.1</okio.version>
+        <retrofit.version>1.9.0</retrofit.version>
+        <okhttp.version>2.2.0</okhttp.version>
+        <okio.version>1.2.0</okio.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
                 <plugin>
                     <groupId>com.day.jcr.vault</groupId>
                     <artifactId>content-package-maven-plugin</artifactId>
-                    <version>0.0.20</version>
+                    <version>0.0.24</version>
                     <extensions>true</extensions>
                     <configuration>
                         <failOnError>true</failOnError>


### PR DESCRIPTION
A version of okio consistent with the release date of okhttp is also updated.  There were some build problems with slf4j and the recent versions of maven, so the content-package-maven-plugin is also upgraded to the latest version.
